### PR TITLE
Add tonic 0.11 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ serde = { version = "1.0.171", features = ["derive"] , optional = true}
 serde_with = { version = "3.0.0", optional = true}
 socket2 = {version="0.5.3", optional=true, features=["all"]}
 tokio = { version = "1.29.1", features = ["net", "io-std", "time", "sync"] }
-tonic = { version = "0.10.2", optional = true }
+tonic = { package = "tonic", version = "0.11.0", optional = true }
+tonic_010 = { package = "tonic", version = "0.10.2", optional = true }
 tracing = "0.1.37"
 axum07 = { version="0.7", package="axum" }
 futures-util = {version="0.3", optional=true}
@@ -69,7 +70,10 @@ sd_listen = []
 socket_options = ["socket2"]
 
 ## Enable `tonic(v0.10)::transport::server::Connected` implementation for [`Connection`]
-tonic010 = ["tonic"]
+tonic010 = ["dep:tonic_010"]
+
+## Enable `tonic(v0.11)::transport::server::Connected` implementation for [`Connection`]
+tonic011 = ["dep:tonic"]
 
 ## Enable [`tokio_util::net::Listener`] implementation for [`Listener`].
 tokio-util = ["dep:tokio-util"]
@@ -83,8 +87,7 @@ hyper014 = { version = "0.14.27", features = ["server", "http1"], package="hyper
 tokio = { version = "1.29.1", features = ["macros", "rt", "io-util"] }
 tokio-test = "0.4.2"
 toml = "0.7.6"
-tonic = { version = "0.10.2" }
-tonic-health = "0.10.2"
+tonic-health = "0.11.0"
 tracing-subscriber = "0.3.17"
 
 [[example]]
@@ -111,7 +114,7 @@ required-features = ["hyper014", "user_facing_default"]
 
 [[example]]
 name = "tonic"
-required-features = ["tonic010"]
+required-features = ["tonic011"]
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1548,6 +1548,48 @@ pub mod axum07;
 #[cfg(feature = "tonic010")]
 #[cfg_attr(docsrs_alt, doc(cfg(feature = "tonic010")))]
 mod tonic010 {
+    use tonic_010::transport::server::{Connected, TcpConnectInfo};
+    #[cfg(all(feature = "unix", unix))]
+    use tonic_010::transport::server::UdsConnectInfo;
+
+    use crate::Connection;
+
+    #[derive(Clone)]
+    pub enum ListenerConnectInfo {
+        Tcp(TcpConnectInfo),
+        #[cfg(all(feature = "unix", unix))]
+        #[cfg_attr(docsrs_alt, doc(cfg(all(feature = "unix", unix))))]
+        Unix(UdsConnectInfo),
+        #[cfg(feature = "inetd")]
+        #[cfg_attr(docsrs_alt, doc(cfg(feature = "inetd")))]
+        Stdio,
+        Other,
+    }
+
+    impl Connected for Connection {
+        type ConnectInfo = ListenerConnectInfo;
+
+        fn connect_info(&self) -> Self::ConnectInfo {
+            if let Some(tcp_stream) = self.try_borrow_tcp() {
+                return ListenerConnectInfo::Tcp(tcp_stream.connect_info());
+            }
+            #[cfg(all(feature = "unix", unix))]
+            if let Some(unix_stream) = self.try_borrow_unix() {
+                return ListenerConnectInfo::Unix(unix_stream.connect_info());
+            }
+            #[cfg(feature = "inetd")]
+            if self.try_borrow_stdio().is_some() {
+                return ListenerConnectInfo::Stdio;
+            }
+
+            ListenerConnectInfo::Other
+        }
+    }
+}
+
+#[cfg(feature = "tonic011")]
+#[cfg_attr(docsrs_alt, doc(cfg(feature = "tonic011")))]
+mod tonic011 {
     use tonic::transport::server::{Connected, TcpConnectInfo};
     #[cfg(all(feature = "unix", unix))]
     use tonic::transport::server::UdsConnectInfo;


### PR DESCRIPTION
This introduces an additional feature flag, tonic011, adding support for tonic 0.11.

This means we need to be able to pull in both tonic 0.10 and tonic 0.12, if we don't want to just drop support for 0.10.

I opted to call the most recent version of tonic "tonic", and renamed tonic 0.10 to tonic_010.