### PR TITLE
WIP: AF_VSOCK support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ tonic010 = ["dep:tonic_010"]
 tonic011 = ["dep:tonic_011"]
 
 ## Enable `tonic(v0.12)::transport::server::Connected` implementation for [`Connection`]
-tonic012 = ["dep:tonic_012", "tokio-vsock?/tonic-conn"]
+tonic012 = ["dep:tonic_012"]
 
 ## Enable [`tokio_util::net::Listener`] implementation for [`Listener`].
 tokio-util = ["dep:tokio-util"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ tonic010 = ["dep:tonic_010"]
 tonic011 = ["dep:tonic_011"]
 
 ## Enable `tonic(v0.12)::transport::server::Connected` implementation for [`Connection`]
-tonic012 = ["dep:tonic_012"]
+tonic012 = ["dep:tonic_012", "tokio-vsock?/tonic-conn"]
 
 ## Enable [`tokio_util::net::Listener`] implementation for [`Listener`].
 tokio-util = ["dep:tokio-util"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ tokio-util = {version = "0.7", optional=true, features=["net","codec"]}
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.26.2", default-features = false, features = ["user", "fs"], optional=true }
 
+[target."cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"macos\"))".dependencies]
+tokio-vsock = {version = "0.5", optional=true}
 
 [features]
 default = ["user_facing_default", "tokio-util"]
@@ -84,6 +86,9 @@ tokio-util = ["dep:tokio-util"]
 
 ## Enable [`Listener::bind_multiple`] and `sd-listen:*` (if combined with `sd_listen` feature)
 multi-listener = ["dep:futures-util"]
+
+## Enable `Vsock` support
+vsock = ["dep:tokio-vsock"]
 
 [dev-dependencies]
 anyhow = "1.0.71"

--- a/src/claptools.rs
+++ b/src/claptools.rs
@@ -29,6 +29,8 @@ pub struct ListenerAddressPositional {
     ///
     /// * UNIX socket path like /tmp/mysock or Linux abstract address like @abstract
     ///
+    /// * AF_VSOCK socket in format vsock:cid:port, example: vsock:42:8080
+    ///
     /// * Special keyword "inetd" for serving one connection from stdin/stdout
     ///
     /// * Special keyword "sd-listen" to accept connections from file descriptor 3 (e.g. systemd socket activation).
@@ -77,6 +79,8 @@ pub struct ListenerAddressLFlag {
     /// * TCP socket address and port, like 127.0.0.1:8080 or [::]:80
     ///
     /// * UNIX socket path like /tmp/mysock or Linux abstract address like @abstract
+    ///
+    /// * AF_VSOCK socket in format vsock:cid:port, example: vsock:42:8080
     ///
     /// * Special keyword "inetd" for serving one connection from stdin/stdout
     ///

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -22,6 +22,9 @@ use tracing::{debug, warn};
 #[cfg(unix)]
 use tokio::net::UnixStream;
 
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+use tokio_vsock::VsockStream;
+
 /// Accepted connection, which can be a TCP socket, AF_UNIX stream socket or a stdin/stdout pair.
 ///
 /// Although inner enum is private, you can use methods or `From` impls to convert this to/from usual Tokio types.
@@ -34,6 +37,8 @@ impl std::fmt::Debug for Connection {
             ConnectionImpl::Tcp(_) => f.write_str("Connection(tcp)"),
             #[cfg(all(feature = "unix", unix))]
             ConnectionImpl::Unix(_) => f.write_str("Connection(unix)"),
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            ConnectionImpl::Vsock(_) => f.write_str("Connection(vsock)"),
             #[cfg(feature = "inetd")]
             ConnectionImpl::Stdio(_, _, _) => f.write_str("Connection(stdio)"),
         }
@@ -52,6 +57,8 @@ pub(crate) enum ConnectionImpl {
         #[pin] tokio::io::Stdout,
         Option<Sender<()>>,
     ),
+    #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+    Vsock(#[pin] VsockStream),
 }
 
 #[allow(missing_docs)]
@@ -88,6 +95,15 @@ impl Connection {
             Err(self)
         }
     }
+    #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+    #[cfg_attr(docsrs_alt, doc(cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))))]
+    pub fn try_into_vsock(self) -> Result<VsockStream, Self> {
+        if let ConnectionImpl::Vsock(vsock) = self.0 {
+            Ok(vsock)
+        } else {
+            Err(self)
+        }
+    }
 
     pub fn try_borrow_tcp(&self) -> Option<&TcpStream> {
         if let ConnectionImpl::Tcp(ref s) = self.0 {
@@ -114,6 +130,15 @@ impl Connection {
             None
         }
     }
+    #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+    #[cfg_attr(docsrs_alt, doc(cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))))]
+    pub fn try_borrow_vsock(&self) -> Option<&VsockStream> {
+        if let ConnectionImpl::Vsock(ref vsock) = self.0 {
+            Some(vsock)
+        } else {
+            None
+        }
+    }
 }
 
 impl From<TcpStream> for Connection {
@@ -136,6 +161,14 @@ impl From<(Stdin, Stdout, Option<Sender<()>>)> for Connection {
     }
 }
 
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+#[cfg_attr(docsrs_alt, doc(cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))))]
+impl From<VsockStream> for Connection {
+    fn from(s: VsockStream) ->Self {
+        Connection(ConnectionImpl::Vsock(s))
+    }
+}
+
 impl AsyncRead for Connection {
     #[inline]
     fn poll_read(
@@ -150,6 +183,8 @@ impl AsyncRead for Connection {
             ConnectionImplProj::Unix(s) => s.poll_read(cx, buf),
             #[cfg(feature = "inetd")]
             ConnectionImplProj::Stdio(s, _, _) => s.poll_read(cx, buf),
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            ConnectionImplProj::Vsock(s) => s.poll_read(cx, buf),
         }
     }
 }
@@ -168,6 +203,8 @@ impl AsyncWrite for Connection {
             ConnectionImplProj::Unix(s) => s.poll_write(cx, buf),
             #[cfg(feature = "inetd")]
             ConnectionImplProj::Stdio(_, s, _) => s.poll_write(cx, buf),
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            ConnectionImplProj::Vsock(s) => s.poll_write(cx, buf),
         }
     }
 
@@ -180,6 +217,8 @@ impl AsyncWrite for Connection {
             ConnectionImplProj::Unix(s) => s.poll_flush(cx),
             #[cfg(feature = "inetd")]
             ConnectionImplProj::Stdio(_, s, _) => s.poll_flush(cx),
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            ConnectionImplProj::Vsock(s) => s.poll_flush(cx),
         }
     }
 
@@ -207,6 +246,8 @@ impl AsyncWrite for Connection {
                     Poll::Ready(ret)
                 }
             },
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            ConnectionImplProj::Vsock(s) => s.poll_shutdown(cx),
         }
     }
 
@@ -223,6 +264,8 @@ impl AsyncWrite for Connection {
             ConnectionImplProj::Unix(s) => s.poll_write_vectored(cx, bufs),
             #[cfg(feature = "inetd")]
             ConnectionImplProj::Stdio(_, s, _) => s.poll_write_vectored(cx, bufs),
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            ConnectionImplProj::Vsock(s) => s.poll_write_vectored(cx, bufs),
         }
     }
 
@@ -234,6 +277,8 @@ impl AsyncWrite for Connection {
             ConnectionImpl::Unix(s) => s.is_write_vectored(),
             #[cfg(feature = "inetd")]
             ConnectionImpl::Stdio(_, s, _) => s.is_write_vectored(),
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            ConnectionImpl::Vsock(s) => s.is_write_vectored(),
         }
     }
 }

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -169,9 +169,9 @@ fn listen_abstract(a: &String, usr_opts: &UserOptions) -> Result<ListenerImpl, s
 }
 
 #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
-fn listen_vsock((cid, port): &(u32, u32)) -> Result<ListenerImpl, std::io::Error> {
+fn listen_vsock(cid: u32, port: u32) -> Result<ListenerImpl, std::io::Error> {
     use tokio_vsock::{VsockAddr, VsockListener};
-    let vs = VsockAddr::new(*cid, *port);
+    let vs = VsockAddr::new(cid, port);
     let listener = VsockListener::bind(vs)?;
     Ok(ListenerImpl::Vsock(ListenerImplVsock{ s: listener}))
 }
@@ -364,7 +364,7 @@ impl Listener {
                 listen_from_fd_named(usr_opts, fdname, sys_opts)?
             }
             #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
-            ListenerAddress::Vsock(vs) => listen_vsock(vs)?,
+            ListenerAddress::Vsock{ cid, port } => listen_vsock(*cid, *port)?,
             #[allow(unreachable_patterns)]
             _ => {
                 #[allow(unused_imports)]
@@ -423,7 +423,7 @@ impl Listener {
                             }
                         }
                     },
-                    ListenerAddress::Vsock(_) => {
+                    ListenerAddress::Vsock{..} => {
                         #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
                         {
                             MissingCompileTimeFeature {

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -49,6 +49,8 @@ impl std::fmt::Debug for Listener {
             ListenerImpl::Unix { .. } => f.write_str("tokio_listener::Listener(unix)"),
             #[cfg(feature = "inetd")]
             ListenerImpl::Stdio(_) => f.write_str("tokio_listener::Listener(stdio)"),
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            ListenerImpl::Vsock(_) => f.write_str("tokio_listener::Listener(vsock)"),
             #[cfg(feature = "multi-listener")]
             ListenerImpl::Multi(ref x) => {
                 write!(f, "tokio_listener::Listener(multi, n={})", x.v.len())
@@ -164,6 +166,14 @@ fn listen_abstract(a: &String, usr_opts: &UserOptions) -> Result<ListenerImpl, s
         #[cfg(feature = "socket_options")]
         send_buffer_size: usr_opts.send_buffer_size,
     }))
+}
+
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+fn listen_vsock((cid, port): &(u32, u32)) -> Result<ListenerImpl, std::io::Error> {
+    use tokio_vsock::{VsockAddr, VsockListener};
+    let vs = VsockAddr::new(*cid, *port);
+    let listener = VsockListener::bind(vs)?;
+    Ok(ListenerImpl::Vsock(ListenerImplVsock{ s: listener}))
 }
 
 #[cfg(all(feature = "sd_listen", unix))]
@@ -353,6 +363,8 @@ impl Listener {
             ListenerAddress::FromFdNamed(fdname) => {
                 listen_from_fd_named(usr_opts, fdname, sys_opts)?
             }
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            ListenerAddress::Vsock(vs) => listen_vsock(vs)?,
             #[allow(unreachable_patterns)]
             _ => {
                 #[allow(unused_imports)]
@@ -410,7 +422,23 @@ impl Listener {
                                 feature: "UNIX-like platform",
                             }
                         }
-                    }
+                    },
+                    ListenerAddress::Vsock(_) => {
+                        #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+                        {
+                            MissingCompileTimeFeature {
+                                reason: "use vsock socket",
+                                feature: "vsock",
+                            }
+                        }
+                        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+                        {
+                            MissingPlatformSupport {
+                                reason: "use vsock socket",
+                                feature: "linux, android or macos platform",
+                            }
+                        }
+                    },
                 };
                 return err.ioerr();
             }
@@ -634,6 +662,11 @@ pub(crate) struct ListenerImplUnix {
     send_buffer_size: Option<usize>,
 }
 
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+pub(crate) struct ListenerImplVsock {
+    pub(crate) s: tokio_vsock::VsockListener,
+}
+
 #[cfg(feature = "multi-listener")]
 pub(crate) struct ListenerImplMulti {
     pub(crate) v: Vec<ListenerImpl>,
@@ -645,6 +678,8 @@ pub(crate) enum ListenerImpl {
     Unix(ListenerImplUnix),
     #[cfg(feature = "inetd")]
     Stdio(StdioListener),
+    #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+    Vsock(ListenerImplVsock),
     #[cfg(feature = "multi-listener")]
     Multi(ListenerImplMulti),
 }
@@ -660,6 +695,8 @@ impl ListenerImpl {
             ListenerImpl::Unix(ui) => ui.poll_accept(cx),
             #[cfg(feature = "inetd")]
             ListenerImpl::Stdio(x) => x.poll_accept(cx),
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            ListenerImpl::Vsock(vs) => vs.poll_accept(cx),
             #[cfg(feature = "multi-listener")]
             ListenerImpl::Multi(x) => x.poll_accept(cx),
         }
@@ -731,6 +768,26 @@ impl ListenerImplUnix {
                     SomeSocketAddr::Unix(a),
                 )))
             }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+impl ListenerImplVsock {
+    fn poll_accept(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::io::Result<(Connection, SomeSocketAddr)>> {
+        match self.s.poll_accept(cx) {
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(Ok((c, a))) => {
+                debug!(r#type = "vsock", "incoming connection");
+                Poll::Ready(Ok((
+                    Connection(ConnectionImpl::Vsock(c)),
+                    SomeSocketAddr::Vsock(a),
+                )))
+            },
             Poll::Pending => Poll::Pending,
         }
     }

--- a/src/some_socket_addr.rs
+++ b/src/some_socket_addr.rs
@@ -14,6 +14,9 @@ pub enum SomeSocketAddr {
     #[cfg(feature = "inetd")]
     #[cfg_attr(docsrs_alt, doc(cfg(feature = "inetd")))]
     Stdio,
+    #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+    #[cfg_attr(docsrs_alt, doc(cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))))]
+    Vsock(tokio_vsock::VsockAddr),
     #[cfg(feature = "multi-listener")]
     #[cfg_attr(docsrs_alt, doc(cfg(feature = "multi-listener")))]
     Multiple,
@@ -27,6 +30,10 @@ impl Display for SomeSocketAddr {
             SomeSocketAddr::Unix(_x) => "unix".fmt(f),
             #[cfg(feature = "inetd")]
             SomeSocketAddr::Stdio => "stdio".fmt(f),
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            SomeSocketAddr::Vsock(x) => {
+                write!(f, "vsock:{}:{}", x.cid(), x.port())
+            },
             #[cfg(feature = "multi-listener")]
             SomeSocketAddr::Multiple => "multiple".fmt(f),
         }
@@ -44,6 +51,8 @@ impl SomeSocketAddr {
             SomeSocketAddr::Unix(x) => SomeSocketAddrClonable::Unix(Arc::new(x)),
             #[cfg(feature = "inetd")]
             SomeSocketAddr::Stdio => SomeSocketAddrClonable::Stdio,
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            SomeSocketAddr::Vsock(x) => SomeSocketAddrClonable::Vsock(x),
             #[cfg(feature = "multi-listener")]
             SomeSocketAddr::Multiple => SomeSocketAddrClonable::Multiple,
         }
@@ -62,6 +71,9 @@ pub enum SomeSocketAddrClonable {
     #[cfg(feature = "inetd")]
     #[cfg_attr(docsrs_alt, doc(cfg(feature = "inetd")))]
     Stdio,
+    #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+    #[cfg_attr(docsrs_alt, doc(cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))))]
+    Vsock(tokio_vsock::VsockAddr),
     #[cfg(feature = "multi-listener")]
     #[cfg_attr(docsrs_alt, doc(cfg(feature = "multi-listener")))]
     Multiple,
@@ -75,6 +87,10 @@ impl Display for SomeSocketAddrClonable {
             SomeSocketAddrClonable::Unix(x) => write!(f, "unix:{x:?}"),
             #[cfg(feature = "inetd")]
             SomeSocketAddrClonable::Stdio => "stdio".fmt(f),
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            SomeSocketAddrClonable::Vsock(x) => {
+                write!(f, "vsock:{}:{}", x.cid(), x.port())
+            },
             #[cfg(feature = "multi-listener")]
             SomeSocketAddrClonable::Multiple => "multiple".fmt(f),
         }

--- a/src/tokioutil.rs
+++ b/src/tokioutil.rs
@@ -24,6 +24,10 @@ impl tokio_util::net::Listener for crate::Listener {
             }) => Ok(SomeSocketAddr::Unix(s.local_addr()?)),
             #[cfg(feature = "inetd")]
             crate::listener::ListenerImpl::Stdio(_) => Ok(SomeSocketAddr::Stdio),
+            #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+            crate::listener::ListenerImpl::Vsock(crate::listener::ListenerImplVsock{s}) => {
+                Ok(SomeSocketAddr::Vsock(s.local_addr()?))
+            },
             #[cfg(feature = "multi-listener")]
             crate::listener::ListenerImpl::Multi(_) => Ok(SomeSocketAddr::Multiple),
         }

--- a/src/tonic012.rs
+++ b/src/tonic012.rs
@@ -1,6 +1,10 @@
+use tonic_012::transport::server::{Connected, TcpConnectInfo};
+
 #[cfg(all(feature = "unix", unix))]
 use tonic_012::transport::server::UdsConnectInfo;
-use tonic_012::transport::server::{Connected, TcpConnectInfo};
+
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+use tokio_vsock::{VsockStream, VsockConnectInfo};
 
 use crate::Connection;
 
@@ -13,6 +17,8 @@ pub enum ListenerConnectInfo {
     #[cfg(feature = "inetd")]
     #[cfg_attr(docsrs_alt, doc(cfg(feature = "inetd")))]
     Stdio,
+    #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+    Vsock(VsockConnectInfo),
     Other,
 }
 
@@ -26,6 +32,10 @@ impl Connected for Connection {
         #[cfg(all(feature = "unix", unix))]
         if let Some(unix_stream) = self.try_borrow_unix() {
             return ListenerConnectInfo::Unix(unix_stream.connect_info());
+        }
+        #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "macos"), feature = "vsock"))]
+        if let Some(vsock_stream) = self.try_borrow_vsock() {
+            return ListenerConnectInfo::Vsock(vsock_stream.connect_info());
         }
         #[cfg(feature = "inetd")]
         if self.try_borrow_stdio().is_some() {


### PR DESCRIPTION
Initial support of AF_VSOCK sockets (vsocks are sockets for virtual machines to host communication).

It basically works, so I like hear some feedback.

Some opinionated things done -- ~~I dropped unused derived traits on ListenerAddr (`Eq`, `Ord` and `Hash`) -- main reason was a VsockAddr,, which is not support `Ord/Hash`~~.

Some things still pending to do:
  - ~~Solve import of `VsockAddr` -- importing it from nix cause version conflict with tonic, importing straight from tokio_vsock make it impossible to build without it.~~
  - Test build on platform not support vsock (I am not super expert in rust's conditional compilation)
  -  Only tonic012 adapter is implemented (and tested, I test everything on tonic app) -- others need to be implemented
  -  Clap integration not implemented
 
Feedback and suggestions welcomed